### PR TITLE
Selvbetjent løsning for å kunne legge til catalog-info

### DIFF
--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
@@ -15,7 +15,7 @@ import {
 } from '@backstage/core-components';
 
 
-import { useApi, githubAuthApiRef } from '@backstage/core-plugin-api';
+import { useApi } from '@backstage/core-plugin-api';
 
 import { catalogImportApiRef } from '@backstage/plugin-catalog-import';
 
@@ -25,14 +25,13 @@ import type { CatalogInfoForm, RequiredYamlFields, Status } from '../../model/ty
 import { CatalogForm } from '../CatalogForm';
 
 import { GithubController } from '../../controllers/githubController';
-import { updateYaml } from '../../translator/translator';
 import { Alert } from '@mui/material';
 
 export const CatalogCreatorPage = () => {
 
   const [url, setUrl] = useState('');
 
-  const [initialYaml, setInitialYaml] = useState<RequiredYamlFields>(undefined);
+  const [initialYaml, setInitialYaml] = useState<RequiredYamlFields | undefined>();
 
   const [catalogInfoForm, setCatalogInfoForm] = useState<CatalogInfoForm>(
     {
@@ -54,8 +53,7 @@ export const CatalogCreatorPage = () => {
   const [status, setStatus] = useState<Status | undefined>()
 
   const catalogImportApi = useApi(catalogImportApiRef);
-  const githubAuth = useApi(githubAuthApiRef);
-  const githubController = new GithubController(catalogImportApi, githubAuth);
+  const githubController = new GithubController(catalogImportApi);
 
   const emptyRequiredYamlFields: RequiredYamlFields = {
     apiVersion: 'backstage.io/v1alpha1',
@@ -75,11 +73,11 @@ export const CatalogCreatorPage = () => {
 
 
     try {
-        const catalogInfoStatus = await githubController.fetchCatalogInfoStatus(url);
-        if (catalogInfoStatus.severity == "success") {
+       const status =  await githubController.fetchCatalogInfoStatus(url);
+        if (status && status.severity == "success") {
           setInitialYaml(emptyRequiredYamlFields);
         }
-        setStatus(catalogInfoStatus)
+        setStatus(status)
     }
     catch(error : unknown) {
       console.error("Could not get catalogInfoStatus", error)
@@ -95,7 +93,6 @@ export const CatalogCreatorPage = () => {
     }
 
     await githubController.submitCatalogInfoToGithub(url, initialYaml, catalogInfoForm);
-    //setYamlContent(updateYaml(initialYaml, catalogInfoForm));
   };
 
   return (

--- a/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
+++ b/plugins/catalog-creator/src/components/CatalogCreatorPage/CatalogCreatorPage.tsx
@@ -89,7 +89,7 @@ export const CatalogCreatorPage = () => {
     }
 
     await githubController.submitCatalogInfoToGithub(url, initialYaml, catalogInfoForm);
-    setYamlContent(updateYaml(initialYaml, catalogInfoForm));
+    //setYamlContent(updateYaml(initialYaml, catalogInfoForm));
   };
 
   return (

--- a/plugins/catalog-creator/src/components/CatalogForm/CatalogForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/CatalogForm.tsx
@@ -26,38 +26,19 @@ export const CatalogForm = (props: CatalogFormProps) => {
         <form onSubmit={props.onSubmit}>
             <Box px={'2rem'}>
                 <Flex direction={'column'} align={'center'}>
-
-                    <Flex direction={'row'} >
-                        <Select
-                            name="Kind"
-                            label="Entity kind"
-                            options={
-                                Object.values(AllowedEntityKinds).map(value => ({
-                                    value: value as AllowedEntityKinds,
-                                    label: value,
-                                }))
-                            }
-                            onSelectionChange={value => {
-                                console.log('Selected kind:', value);
-                                props.setCatalogInfoForm({ ...props.catalogInfoForm, kind: value as AllowedEntityKinds });
-                            }}
-                            placeholder="Select kind"
-                        />
-
-                        <TextField
-                            name="Name"
-                            label="Entity name"
-                            value={props.catalogInfoForm.name}
-                            onChange={(e: any) => {
-                                console.log('Entity name changed:', e);
-                                props.setCatalogInfoForm({ ...props.catalogInfoForm, name: e });
-                            }}
-                        />
-                    </Flex>
+                <TextField
+                    name="Name"
+                    label="Entity name *"
+                    value={props.catalogInfoForm.name}
+                    onChange={(e: any) => {
+                        console.log('Entity name changed:', e);
+                        props.setCatalogInfoForm({ ...props.catalogInfoForm, name: e });
+                    }}
+                />
 
                     <TextField
                         name="Owner"
-                        label="Entity owner"
+                        label="Entity owner *"
                         value={props.catalogInfoForm.owner}
                         onChange={(e: any) => {
                             console.log('Entity owner changed:', e);
@@ -65,10 +46,10 @@ export const CatalogForm = (props: CatalogFormProps) => {
                         }}
                     />
 
-                    <Flex direction={'row'} align={'center'}>
+                    <Flex>
                         <Select
                             name="Lifecycle"
-                            label="Entity lifecycle"
+                            label="Entity lifecycle *"
                             options={
                                 Object.values(AllowedLifecycleStages).map(value => ({
                                     value: value as AllowedLifecycleStages,
@@ -84,7 +65,7 @@ export const CatalogForm = (props: CatalogFormProps) => {
 
                         <Select
                             name="Type"
-                            label="Entity type"
+                            label="Entity type *"
                             options={
                                 Object.values(AllowedEntityTypes).map(value => ({
                                     value: value as AllowedEntityTypes,
@@ -106,16 +87,6 @@ export const CatalogForm = (props: CatalogFormProps) => {
                         onChange={(e: any) => {
                             console.log('Entity system changed:', e);
                             props.setCatalogInfoForm({ ...props.catalogInfoForm, system: e });
-                        }}
-                    />
-
-                    <TextField
-                        name="Domain"
-                        label="Entity domain"
-                        value={props.catalogInfoForm.domain}
-                        onChange={(e: any) => {
-                            console.log('Entity domain changed:', e);
-                            props.setCatalogInfoForm({ ...props.catalogInfoForm, domain: e });
                         }}
                     />
 

--- a/plugins/catalog-creator/src/components/CatalogForm/CatalogForm.tsx
+++ b/plugins/catalog-creator/src/components/CatalogForm/CatalogForm.tsx
@@ -3,11 +3,11 @@ import {
     Box,
     Flex,
     Select,
-    TextField
+    TextField,
 } from '@backstage/ui';
 
 import type { CatalogInfoForm } from '../../model/types';
-import { AllowedEntityKinds, AllowedLifecycleStages, AllowedEntityTypes } from '../../model/types';
+import { AllowedLifecycleStages, AllowedEntityTypes } from '../../model/types';
 
 import { DownloadButton } from '../DownloadButton';
 
@@ -25,7 +25,8 @@ export const CatalogForm = (props: CatalogFormProps) => {
     return (
         <form onSubmit={props.onSubmit}>
             <Box px={'2rem'}>
-                <Flex direction={'column'} align={'center'}>
+                <h1>Catalog-info.yaml Form</h1>
+                <Flex direction={'column'} justify={"start"}>
                 <TextField
                     name="Name"
                     label="Entity name *"

--- a/plugins/catalog-creator/src/controllers/githubController.ts
+++ b/plugins/catalog-creator/src/controllers/githubController.ts
@@ -1,11 +1,11 @@
 import { OAuthApi } from '@backstage/core-plugin-api';
 import type { CatalogImportApi } from '@backstage/plugin-catalog-import';
 
-import type { CatalogInfoForm, RequiredYamlFields } from '../model/types.ts';
+import type { CatalogInfoForm, RequiredYamlFields, Status } from '../model/types.ts';
 
 import yaml from 'yaml';
 
-import { updateYaml } from '../translator/translator.ts';
+import { updateYaml } from '../translator/translator';
 
 export class GithubController {
     constructor(
@@ -50,57 +50,50 @@ export class GithubController {
         }
     };
 
-    fetchCatalogInfo = async (url: string): Promise<RequiredYamlFields | undefined> => {
+    fetchCatalogInfoStatus = async (url: string): Promise<Status> => {
 
         const match = url.match(/github\.com\/([^\/]+)\/([^\/]+)/);
         if (!match) {
-            console.log('Invalid GitHub repository URL');
-            return;
+            throw new Error("Invalid Github URL");
         }
 
         const owner = match[1];
         const repo = match[2];
 
-        const token = await this.githubAuthApi.getAccessToken();
-
-        // If no entityData, just check if catalog-info.yaml exists and fetch it
-        const response = await fetch(
+        
+        try {
+            const token = await this.githubAuthApi.getAccessToken();
+            const response = await fetch(
             `https://api.github.com/repos/${owner}/${repo}/contents/catalog-info.yaml`,
             {
                 headers: {
                     Authorization: `token ${token}`,
                     Accept: 'application/vnd.github.v3+json',
                 },
-            }
-        );
+            });
 
-        if (response.ok) {
-            const data = await response.json();
-            const content = atob(data.content);
-            try {
-                const parsed = yaml.parse(content);
-                return parsed;
-            } catch (error) {
-                console.error('Error parsing YAML content:', error);
-                return;
-            }
-
-        } else if (response.status === 404) {
-            const emptyRequiredYamlFields: RequiredYamlFields = {
-                apiVersion: 'backstage.io/v1alpha1',
-                kind: "",
-                metadata: {
-                    name: ''
-                },
-                spec: {
-                    type: "",
+            if (response.ok) {
+                return {
+                    message: "Catalog-info.yaml already exists",
+                    severity: "info"
                 }
-                };
-            console.log('catalog-info.yaml does not exist in the repository.');
-            return emptyRequiredYamlFields;
-        } else {
-            console.log('Error checking catalog-info.yaml:', response.statusText);
-            return;
+
+            } else if (response.status === 404) {
+                return {
+                    message: "Github repository found",
+                    severity: "success"
+                }
+            } else {
+            return {
+                    message: `Error checking catalog-info.yaml: ${response.statusText}`,
+                    severity: "error"
+                }
+            }
+        } catch(error) {
+            console.error("Could not retrieve github repo ", error)
         }
+    
+
+        // If no entityData, just check if catalog-info.yaml exists and fetch it
     }
 }

--- a/plugins/catalog-creator/src/controllers/githubController.ts
+++ b/plugins/catalog-creator/src/controllers/githubController.ts
@@ -86,8 +86,18 @@ export class GithubController {
             }
 
         } else if (response.status === 404) {
+            const emptyRequiredYamlFields: RequiredYamlFields = {
+                apiVersion: 'backstage.io/v1alpha1',
+                kind: "",
+                metadata: {
+                    name: ''
+                },
+                spec: {
+                    type: "",
+                }
+                };
             console.log('catalog-info.yaml does not exist in the repository.');
-            return;
+            return emptyRequiredYamlFields;
         } else {
             console.log('Error checking catalog-info.yaml:', response.statusText);
             return;

--- a/plugins/catalog-creator/src/model/types.ts
+++ b/plugins/catalog-creator/src/model/types.ts
@@ -32,6 +32,11 @@ export type CatalogInfoForm = {
     definition?: string[];
 };
 
+export type Status = {
+    message: string,
+    severity: 'error' | 'success' | 'warning' | 'info'
+}
+
 export type RequiredYamlFields = {
     apiVersion: 'backstage.io/v1alpha1';
     kind: string;

--- a/plugins/catalog-creator/src/translator/translator.ts
+++ b/plugins/catalog-creator/src/translator/translator.ts
@@ -7,6 +7,7 @@ export const updateYaml = (initial: RequiredYamlFields, form: CatalogInfoForm): 
 
     const updated: RequiredYamlFields = {
         ...initial,
+        kind: form.kind!,
         metadata: {
             ...initial.metadata,
             name: form.name,
@@ -21,6 +22,7 @@ export const updateYaml = (initial: RequiredYamlFields, form: CatalogInfoForm): 
             consumesApis: form.consumesApis?.length ? form.consumesApis : undefined,
             dependsOn: form.dependsOn?.length ? form.dependsOn : undefined,
             definition: form.definition?.length ? form.definition : undefined,
+            type: form.type!
         }
     };
 


### PR DESCRIPTION
# Hva har blitt lagt til
- Mulighet for å hente repoer og vurdere om de har catalog-info vha catalogimport API
- Feilhåndtering og visning av form hvis repoet finnes men mangler catalog-info

## Hva mangler for selvbetjening
- Form validation gjenstår for å få en fungerende løsning som kan gå i prod.