### PR TITLE
bump version tag

### DIFF
--- a/plugins/catalog-creator/package.json
+++ b/plugins/catalog-creator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kartverket/plugin-catalog-creator",
-  "version": "0.1.5",
+  "version": "1.0.0",
   "license": "Apache-2.0",
   "main": "src/index.ts",
   "types": "src/index.ts",


### PR DESCRIPTION
Vi trenger å bumpe versjonstagen for å få den på NPM. I og med at vi ønsker at dette nå er en stabil funksjon som vi kan utvide videre ved å inkrementere minor eller patch changes  **0.1.5 -> 1.0.0**.